### PR TITLE
Fill in most fields in studio.cgi response (Mii Studio code) & fix inaccurate eyebrows for studio data input

### DIFF
--- a/mii/render.go
+++ b/mii/render.go
@@ -30,7 +30,7 @@ func Render(c *gin.Context) {
 	studioMii := CreateStudioMii(m, Wii)
 
 	queryParams := url.Values{
-		"data":          {studioMii},
+		"data":          {studioMii.Mii},
 		"type":          {"face"},
 		"width":         {"512"},
 		"instanceCount": {"1"},


### PR DESCRIPTION
Sorry for the extra PR today. With this change, a response from this server will now look like this on pf2m.com/tools/mii.
The studio.cgi endpoint did not return the "Mii Studio Code" prior, or the name and creator name fields.

As you can see there are still some fields not filled in:
* Birthday
* Mingle (local only)
* Copying

... However, hearing that some people use this site for converting Miis to Mii Studio codes, I think it's fine to exclude those for now.
<img src="https://github.com/user-attachments/assets/678e85f4-a62f-400e-90d7-bd8f8593fe24" width="400">
